### PR TITLE
removed the password autoset

### DIFF
--- a/admin/DBEdit.js
+++ b/admin/DBEdit.js
@@ -13,8 +13,6 @@ window.queueEdit = saveEdit
 window.deleteEntry = deleteEntry
 window.newEntry = newEntry
 
-password.value = "password"
-
 export async function loadDB(name) {
 
     let primaryKeyColumns


### PR DESCRIPTION
Allows for editing the database. Sequelize limitations prevent modification of primary keys, which will be changed